### PR TITLE
Bugfix in M365 Dumper Module

### DIFF
--- a/goosey/m365_datadumper.py
+++ b/goosey/m365_datadumper.py
@@ -275,7 +275,8 @@ class M365DataDumper(DataDumper):
                 with open(outfile, 'a', encoding="utf-8") as f:
                     if result:
                         result.update(y)
-                        del result['@odata.context']
+                        if '@odata.context' in result.keys():
+                            del result['@odata.context']
                         f.write(json.dumps(result))
                         f.write("\n")
         
@@ -301,7 +302,8 @@ class M365DataDumper(DataDumper):
                 with open(outfile, 'a', encoding="utf-8") as f:
                     if result:
                         result.update(y)
-                        del result['@odata.context']
+                        if '@odata.context' in result.keys():
+                            del result['@odata.context']
                         f.write(json.dumps(result))
                         f.write("\n")
         


### PR DESCRIPTION
# <!-- Use the title to describe PR changes in the imperative mood --> #

## 🗣 Description ##

This PR fixes a bug in the M365 dumper module. The bug produces an `KeyError` exception which leads to a crash of the application. 


## 💭 Motivation and context ##

The exception is thrown in the function `dump_exo_mailbox` of the `m365_datadumper.py`. The complete stack trace can be found below.

```
Traceback (most recent call last):
  File "venv/goose/bin/goosey", line 11, in <module>
    load_entry_point('goosey==1.1.0', 'console_scripts', 'goosey')()
  File "venv/goose/lib/python3.8/site-packages/goosey/main.py", line 89, in main
    honkmain(args)
  File "venv/goose/lib/python3.8/site-packages/goosey/honk.py", line 278, in main
    asyncio.run(run(args, config, auth, auth_un_pw))
  File "/usr/lib/python3.8/asyncio/runners.py", line 44, in run
    return loop.run_until_complete(main)
  File "/usr/lib/python3.8/asyncio/base_events.py", line 616, in run_until_complete
    return future.result()
  File "venv/goose/lib/python3.8/site-packages/goosey/honk.py", line 145, in run
    await asyncio.gather(*tasks)
  File "venv/goose/lib/python3.8/site-packages/goosey/m365_datadumper.py", line 278, in dump_exo_mailbox
    del result['@odata.context']
KeyError: '@odata.context'
```

As seen in the stack trace the key `@odata.context` is not part of the `result` dictionary. Thus, I suggest to check whether the key exists beforehand.


## 🧪 Testing ##

This PR was tested manually against a Microsoft 365 development tenant (E5 license).

<!--
## 📷 Screenshots (if appropriate) ##

Uncomment this section if a screenshot is needed.

-->

## ✅ Pre-approval checklist ##

<!-- Remove any of the following that do not apply. -->
<!-- Draft PRs should have one or more unchecked boxes. -->
<!-- If you're unsure about any of these, don't hesitate to ask. -->
<!-- We're here to help! -->

- [x] This PR has an informative and human-readable title.
- [x] Changes are limited to a single goal - *eschew scope creep!*
- [x] *All* future TODOs are captured in issues, which are referenced
      in code comments.
- [ ] All relevant type-of-change labels have been added.
- [x] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
- [ ] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
- [ ] All relevant repo and/or project documentation has been updated
      to reflect the changes in this PR.
- [ ] Tests have been added and/or modified to cover the changes in this PR.
- [ ] All new and existing tests pass.

## ✅ Pre-merge checklist ##

<!-- Remove any of the following that do not apply. -->
<!-- These boxes should remain unchecked until the pull request has been -->
<!-- approved. -->

- [ ] Revert dependencies to default branches.
- [ ] Finalize version.

## ✅ Post-merge checklist ##

<!-- Remove any of the following that do not apply. -->

- [ ] Create a release.
