### PR TITLE
Fix variable to correct import

### DIFF
--- a/scripts/Create_SP.ps1
+++ b/scripts/Create_SP.ps1
@@ -106,7 +106,7 @@ Function Install-Single-Module {
 	# Import it if not currently installed
 	If ($null -eq (Get-InstalledModule $ModuleName -RequiredVersion $Version)) {
 		Write-Host "Importing $ModuleName"
-		Import-Module -Name $ModuleNAme -RequiredVersion $AzVersion -Force
+		Import-Module -Name $ModuleNAme -RequiredVersion $Version -Force
 	}
 }
 


### PR DESCRIPTION
The `$AzVersion` variable was mistakenly used on an import cmdlet that is designed to import several different modules.

